### PR TITLE
Detect ASUS USB-N13 C1 WLAN stick based on RTL8192FU

### DIFF
--- a/os_dep/linux/usb_intf.c
+++ b/os_dep/linux/usb_intf.c
@@ -249,6 +249,7 @@ static struct usb_device_id rtw_usb_id_tbl[] = {
 	/*=== Realtek demoboard ===*/
 	{USB_DEVICE_AND_INTERFACE_INFO(USB_VENDER_ID_REALTEK, 0xF192, 0xff, 0xff, 0xff), .driver_info = RTL8192F}, /* 8192FU 2*2 */
 	{USB_DEVICE_AND_INTERFACE_INFO(USB_VENDER_ID_REALTEK, 0xA725, 0xff, 0xff, 0xff), .driver_info = RTL8192F}, /* 8725AU 2*2 */
+	{USB_DEVICE(0x0B05, 0x18F1), .driver_info = RTL8192F}, /* ASUS USB-N13 */
 #endif
 
 #ifdef CONFIG_RTL8821C


### PR DESCRIPTION
Added USB device info for
usb 1-4: New USB device found, idVendor=0b05, idProduct=18f1, bcdDevice= 2.00
usb 1-4: New USB device strings: Mfr=1, Product=2, SerialNumber=3
usb 1-4: Product: 802.11n  WLAN Adapter
usb 1-4: Manufacturer: Realtek